### PR TITLE
Fix card link, title, description & background colors not applying with rgb/rgba values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Requires at least:** 4.4  
 **Tags:** beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder  
 **Stable tag:** 1.1.8  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
  

--- a/bb-bootstrap-cards-module/includes/frontend.css.php
+++ b/bb-bootstrap-cards-module/includes/frontend.css.php
@@ -5,12 +5,36 @@
  * @package  bb-bootstrap-cards
  */
 
+/**
+ * Helper function to format color value for CSS output.
+ * Handles: rgb(), rgba(), hex with #, hex without #
+ *
+ * @since 1.0.0
+ */
+if ( ! function_exists( 'bb_cards_format_color' ) ) {
+	function bb_cards_format_color( $color, $default = '' ) {
+		if ( empty( $color ) ) {
+			return $default ? bb_cards_format_color( $default ) : '';
+		}
+		// If it's rgb/rgba format, return as-is.
+		if ( strpos( $color, 'rgb' ) === 0 ) {
+			return $color;
+		}
+		// If it starts with #, return as-is.
+		if ( strpos( $color, '#' ) === 0 ) {
+			return $color;
+		}
+		// Otherwise, it's a hex without #, add it.
+		return '#' . $color;
+	}
+}
+
 ?>
 
 /* Background Property */
 <?php if ( ! empty( $settings->bg_color ) ) : ?>
 .fl-node-<?php echo $id; ?> .bb_boot_card_container { 
-	background-color: #<?php echo $settings->bg_color; ?>;
+	background-color: <?php echo bb_cards_format_color( $settings->bg_color ); ?>;
 	background: rgba(<?php echo implode( ',', FLBuilderColor::hex_to_rgb( $settings->bg_color ) ); ?>, <?php echo ( '' != $settings->bg_color_opc ) ? $settings->bg_color_opc / 100 : 100; ?>);
 }
 <?php endif; ?>
@@ -26,7 +50,7 @@
 .fl-node-<?php echo $id; ?> .bb_boot_card_title,
 .fl-node-<?php echo $id; ?> .bb_boot_card_title * {
 <?php if ( ! empty( $settings->color ) ) : ?>
-	color: #<?php echo $settings->color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->title_size ) : ?>
@@ -60,7 +84,7 @@ margin-bottom: <?php echo ( trim( $settings->title_margin_bottom ) != '' ) ? $se
 
 .fl-node-<?php echo $id; ?> .bb_boot_card_link, .fl-node-<?php echo $id; ?> .bb_boot_card_link:visited {
 <?php if ( ! empty( $settings->link_color ) ) : ?>
-	color: #<?php echo $settings->link_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->link_color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->link_font_size ) : ?>
@@ -78,7 +102,7 @@ margin-bottom: <?php echo ( trim( $settings->title_margin_bottom ) != '' ) ? $se
 
 .fl-node-<?php echo $id; ?> .bb_boot_card_link:hover {
 <?php if ( ! empty( $settings->link_hover_color ) ) : ?>
-	color: #<?php echo $settings->link_hover_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->link_hover_color ); ?>;
 <?php endif; ?>
 }
 
@@ -105,7 +129,7 @@ display:block;
 .fl-node-<?php echo $id; ?> .bb_boot_card_block .bb_boot_card_text,
 .fl-node-<?php echo $id; ?> .bb_boot_card_block .bb_boot_card_text * {
 <?php if ( ! empty( $settings->desc_color ) ) : ?>
-	color: #<?php echo $settings->desc_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->desc_color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->desc_font_size ) : ?>
@@ -133,28 +157,6 @@ margin-bottom: <?php echo ( trim( $settings->desc_margin_bottom ) != '' ) ? $set
 /* BCard's Button Link */
 <?php if ( 'button' == $settings->card_btn_type ) : ?>
 <?php
-	/**
-	 * Helper function to format color value for CSS output.
-	 * Handles: rgb(), rgba(), hex with #, hex without #
-	 */
-	if ( ! function_exists( 'bb_cards_format_color' ) ) {
-		function bb_cards_format_color( $color, $default = '' ) {
-			if ( empty( $color ) ) {
-				return $default ? bb_cards_format_color( $default ) : '';
-			}
-			// If it's rgb/rgba format, return as-is
-			if ( strpos( $color, 'rgb' ) === 0 ) {
-				return $color;
-			}
-			// If it starts with #, return as-is
-			if ( strpos( $color, '#' ) === 0 ) {
-				return $color;
-			}
-			// Otherwise, it's a hex without #, add it
-			return '#' . $color;
-		}
-	}
-
 	// Get button colors with fallback to defaults
 	$btn_bg_color = bb_cards_format_color(
 		isset( $settings->btn_bg_color ) ? $settings->btn_bg_color : '',

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder
 Stable tag: 1.1.8
-Tested up to: 6.9
+Tested up to: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  


### PR DESCRIPTION
Closes #59

## Summary

- Card link/hover, title, description, and background colors were not applying on the frontend when set via Beaver Builder's color picker.
- Root cause: the CSS template hard-coded a \`#\` prefix on every color value (e.g. \`color: #<?php echo \$settings->link_color; ?>\`), assuming bare hex. The current BB color picker stores \`rgb()\`/\`rgba()\` values, producing invalid declarations like \`color: #rgb(233, 37, 37)\` that browsers silently discard — so colors fell back to the theme default.
- Routed all color outputs through the existing \`bb_cards_format_color()\` helper (already used by the button colors), and moved that helper to the top of the template so it is defined before the link section. It passes \`rgb()\`/\`rgba()\`/\`#hex\` through untouched and only prepends \`#\` to a bare hex.

## Fields fixed
- \`link_color\` / \`link_hover_color\` (card link + hover)
- \`color\` (card title)
- \`desc_color\` (card description)
- \`bg_color\` (card background-color fallback line; the rgba shorthand already worked via \`FLBuilderColor::hex_to_rgb()\`)

## Test plan
- Add a Bootstrap Card module and set link, hover, title, description, and background colors using the color picker.
- View the page on the frontend and confirm each color renders as chosen.
- Verified on \`/cards-for-bb/\` — computed styles after the fix:
  - link: \`rgb(233, 37, 37)\`, hover rule: \`rgb(52, 203, 6)\`
  - title: \`rgb(30, 41, 59)\`, description: \`rgb(9, 236, 217)\`
  - background: \`rgba(225, 55, 55, 0.1)\`
  - zero invalid \`#rgb(...)\` rules remain in the generated layout CSS.
- \`php -l\` passes on the modified template.