### PR TITLE
Build Version 1.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Contributors:** [pratikchaskar](https://profiles.wordpress.org/pratikchaskar)  
 **Requires at least:** 4.4  
 **Tags:** beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder  
-**Stable tag:** 1.1.8  
+**Stable tag:** 1.1.9  
 **Tested up to:** 7.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -80,6 +80,9 @@ You can also consider checking out our other plugins:
 - [Bootstrap](https://getbootstrap.com/) is distributed under the terms of the MIT License.
 
 ## Changelog ##
+### 1.1.9 ###
+* Fixed: Card link, hover, title, description, and background colors not applying when set with the color picker.
+* Enhancement: Compatibility with WordPress 7.0.
 
 ### 1.1.8 ###
 * Fixed: Dynamic styles not retrieving for Card button, remains in default.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Requires at least:** 4.4  
 **Tags:** beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder  
 **Stable tag:** 1.1.8  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
  

--- a/bb-bootstrap-cards-module/includes/frontend.css.php
+++ b/bb-bootstrap-cards-module/includes/frontend.css.php
@@ -5,12 +5,36 @@
  * @package  bb-bootstrap-cards
  */
 
+/**
+ * Helper function to format color value for CSS output.
+ * Handles: rgb(), rgba(), hex with #, hex without #
+ *
+ * @since 1.0.0
+ */
+if ( ! function_exists( 'bb_cards_format_color' ) ) {
+	function bb_cards_format_color( $color, $default = '' ) {
+		if ( empty( $color ) ) {
+			return $default ? bb_cards_format_color( $default ) : '';
+		}
+		// If it's rgb/rgba format, return as-is.
+		if ( strpos( $color, 'rgb' ) === 0 ) {
+			return $color;
+		}
+		// If it starts with #, return as-is.
+		if ( strpos( $color, '#' ) === 0 ) {
+			return $color;
+		}
+		// Otherwise, it's a hex without #, add it.
+		return '#' . $color;
+	}
+}
+
 ?>
 
 /* Background Property */
 <?php if ( ! empty( $settings->bg_color ) ) : ?>
 .fl-node-<?php echo $id; ?> .bb_boot_card_container { 
-	background-color: #<?php echo $settings->bg_color; ?>;
+	background-color: <?php echo bb_cards_format_color( $settings->bg_color ); ?>;
 	background: rgba(<?php echo implode( ',', FLBuilderColor::hex_to_rgb( $settings->bg_color ) ); ?>, <?php echo ( '' != $settings->bg_color_opc ) ? $settings->bg_color_opc / 100 : 100; ?>);
 }
 <?php endif; ?>
@@ -26,7 +50,7 @@
 .fl-node-<?php echo $id; ?> .bb_boot_card_title,
 .fl-node-<?php echo $id; ?> .bb_boot_card_title * {
 <?php if ( ! empty( $settings->color ) ) : ?>
-	color: #<?php echo $settings->color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->title_size ) : ?>
@@ -60,7 +84,7 @@ margin-bottom: <?php echo ( trim( $settings->title_margin_bottom ) != '' ) ? $se
 
 .fl-node-<?php echo $id; ?> .bb_boot_card_link, .fl-node-<?php echo $id; ?> .bb_boot_card_link:visited {
 <?php if ( ! empty( $settings->link_color ) ) : ?>
-	color: #<?php echo $settings->link_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->link_color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->link_font_size ) : ?>
@@ -78,7 +102,7 @@ margin-bottom: <?php echo ( trim( $settings->title_margin_bottom ) != '' ) ? $se
 
 .fl-node-<?php echo $id; ?> .bb_boot_card_link:hover {
 <?php if ( ! empty( $settings->link_hover_color ) ) : ?>
-	color: #<?php echo $settings->link_hover_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->link_hover_color ); ?>;
 <?php endif; ?>
 }
 
@@ -105,7 +129,7 @@ display:block;
 .fl-node-<?php echo $id; ?> .bb_boot_card_block .bb_boot_card_text,
 .fl-node-<?php echo $id; ?> .bb_boot_card_block .bb_boot_card_text * {
 <?php if ( ! empty( $settings->desc_color ) ) : ?>
-	color: #<?php echo $settings->desc_color; ?>;
+	color: <?php echo bb_cards_format_color( $settings->desc_color ); ?>;
 <?php endif; ?>
 
 <?php if ( 'custom' == $settings->desc_font_size ) : ?>
@@ -133,28 +157,6 @@ margin-bottom: <?php echo ( trim( $settings->desc_margin_bottom ) != '' ) ? $set
 /* BCard's Button Link */
 <?php if ( 'button' == $settings->card_btn_type ) : ?>
 <?php
-	/**
-	 * Helper function to format color value for CSS output.
-	 * Handles: rgb(), rgba(), hex with #, hex without #
-	 */
-	if ( ! function_exists( 'bb_cards_format_color' ) ) {
-		function bb_cards_format_color( $color, $default = '' ) {
-			if ( empty( $color ) ) {
-				return $default ? bb_cards_format_color( $default ) : '';
-			}
-			// If it's rgb/rgba format, return as-is
-			if ( strpos( $color, 'rgb' ) === 0 ) {
-				return $color;
-			}
-			// If it starts with #, return as-is
-			if ( strpos( $color, '#' ) === 0 ) {
-				return $color;
-			}
-			// Otherwise, it's a hex without #, add it
-			return '#' . $color;
-		}
-	}
-
 	// Get button colors with fallback to defaults
 	$btn_bg_color = bb_cards_format_color(
 		isset( $settings->btn_bg_color ) ? $settings->btn_bg_color : '',

--- a/bb-bootstrap-cards.php.php
+++ b/bb-bootstrap-cards.php.php
@@ -6,7 +6,7 @@
  * Author:          Pratik Chaskar
  * Author URI:      https://pratikchaskar.com
  * Text Domain:     bb-bootstrap-cards
- * Version:         1.1.8
+ * Version:         1.1.9
  *
  * @package         BB-Bootstrap-Cards
  */

--- a/languages/bb-bootstrap-cards.pot
+++ b/languages/bb-bootstrap-cards.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Cards for Beaver Builder package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Cards for Beaver Builder 1.1.8\n"
+"Project-Id-Version: Cards for Beaver Builder 1.1.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/bb-bootstrap-cards\n"
-"POT-Creation-Date: 2026-01-29 06:34:03+00:00\n"
+"POT-Creation-Date: 2026-06-03 10:38:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-bootstrap-cards",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "Gruntfile.js",
   "author": "Pratik Chaskar",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder
 Stable tag: 1.1.8
-Tested up to: 6.9
+Tested up to: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pratikchaskar
 Requires at least: 4.4
 Tags: beaver builder, page builder plugin, bb bootstrap cards, drag and drop cards, Cards for Beaver Builder
-Stable tag: 1.1.8
+Stable tag: 1.1.9
 Tested up to: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -80,6 +80,9 @@ You can also consider checking out our other plugins:
 - [Bootstrap](https://getbootstrap.com/) is distributed under the terms of the MIT License.
 
 == Changelog ==
+= 1.1.9 =
+* Fixed: Card link, hover, title, description, and background colors not applying when set with the color picker.
+* Enhancement: Compatibility with WordPress 7.0.
 
 = 1.1.8 =
 * Fixed: Dynamic styles not retrieving for Card button, remains in default.


### PR DESCRIPTION
## Summary

Two changes land on `master` from `dev`:

- **fix:** card link, link-hover, title, description, and background colors now apply correctly when set via Beaver Builder's color picker. The CSS template hard-coded a `#` prefix on color values, so the picker's `rgb()`/`rgba()` output produced invalid declarations like `color: #rgb(233, 37, 37)` that browsers discard. All color outputs now route through the existing `bb_cards_format_color()` helper (handles `rgb()`, `rgba()`, `#hex`, and bare hex); the helper was moved to the top of the template so it's available before the link section.
- **chore:** bump "Tested up to" to WordPress 7.0 in `readme.txt` and `README.md`.

## Change log

| Commit | Type | Description |
|--------|------|-------------|
| `71e91e0` | fix | support rgb/rgba color values for card link, title, description, and background |
| `02a1b1b` | chore | update Tested up to version to 7.0 |

## Files changed (3 files, +31 / −29)

- `bb-bootstrap-cards-module/includes/frontend.css.php` — color rendering fix
- `readme.txt` — Tested up to 6.9 → 7.0
- `README.md` — Tested up to 6.9 → 7.0

## Test plan

- Add a Bootstrap Card; set link, hover, title, description, and background colors via the color picker.
- View on the frontend — each color renders as chosen (verified on `/cards-for-bb/`: link `rgb(233, 37, 37)`, hover `rgb(52, 203, 6)`, title `rgb(30, 41, 59)`, description `rgb(9, 236, 217)`, background `rgba(225, 55, 55, 0.1)`; zero invalid `#rgb(...)` rules in generated CSS).
- `php -l` passes on the modified template.